### PR TITLE
Change XP blocks to store experience instead of levels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "1.0"
-group = "com.yourname.modid" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "modid"
+version = "1.4"
+group = "b4ckscor3.globalxp" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+archivesBaseName = "GlobalXP"
 
 sourceCompatibility = targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 compileJava {

--- a/src/main/java/bl4ckscor3/mod/globalxp/GlobalXP.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/GlobalXP.java
@@ -29,7 +29,7 @@ public class GlobalXP
 {
 	public static final String MOD_ID = "globalxp";
 	public static final String NAME = "Global XP";
-	public static final String VERSION = "v1.3";
+	public static final String VERSION = "v1.4";
 	public static final String MC_VERSION = "1.12"; //1.12.1 also works
 	public static final String GUI_FACTORY = "bl4ckscor3.mod.globalxp.gui.GUIFactory";
 	public static Block xp_block;

--- a/src/main/java/bl4ckscor3/mod/globalxp/handlers/EventHandler.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/handlers/EventHandler.java
@@ -4,6 +4,7 @@ import bl4ckscor3.mod.globalxp.GlobalXP;
 import bl4ckscor3.mod.globalxp.blocks.XPBlock;
 import bl4ckscor3.mod.globalxp.tileentity.TileEntityXPBlock;
 import net.minecraft.util.EnumHand;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent.OnConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -18,20 +19,24 @@ public class EventHandler
 
 		if(!event.getWorld().isRemote)
 		{
-			if(event.getEntityPlayer().isSneaking()) //add all levels to the block
+			if(event.getEntityPlayer().isSneaking())
 			{
-				((TileEntityXPBlock)event.getWorld().getTileEntity(event.getPos())).addLevel(event.getEntityPlayer().experienceLevel);
-				event.getEntityPlayer().addExperienceLevel(-event.getEntityPlayer().experienceLevel);
+				// Sneaking = add all player XP to the block
+
+				((TileEntityXPBlock)event.getWorld().getTileEntity(event.getPos())).addXp(event.getEntityPlayer().experienceTotal);
+				event.getEntityPlayer().addExperienceLevel(-event.getEntityPlayer().experienceLevel - 1); // set player XP to 0
 			}
-			else //remove one level from the block
+			else
 			{
+				// Not sneaking = remove exactly enough XP from the block to get player to the next level
+
 				TileEntityXPBlock te = ((TileEntityXPBlock)event.getWorld().getTileEntity(event.getPos()));
+				EntityPlayer player = event.getEntityPlayer();
+
+				int neededXp = player.xpBarCap() - (int)player.experience;
+				int availableXp = te.removeXp(neededXp);
 				
-				if(te.getStoredLevels() == 0)
-					return;
-				
-				te.removeLevel();
-				event.getEntityPlayer().addExperienceLevel(1);
+				event.getEntityPlayer().addExperience(availableXp);
 			}
 		}
 	}

--- a/src/main/java/bl4ckscor3/mod/globalxp/imc/waila/WailaDataProvider.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/imc/waila/WailaDataProvider.java
@@ -33,7 +33,7 @@ public class WailaDataProvider implements IWailaDataProvider
 	@Override
 	public List<String> getWailaBody(ItemStack arg0, List<String> arg1, IWailaDataAccessor arg2, IWailaConfigHandler arg3)
 	{
-		arg1.add(I18n.format("waila.body", ((TileEntityXPBlock)arg2.getTileEntity()).getStoredLevels()));
+		arg1.add(I18n.format("waila.body", String.format("%.2f", ((TileEntityXPBlock)arg2.getTileEntity()).getStoredLevels())));
 		return arg1;
 	}
 

--- a/src/main/java/bl4ckscor3/mod/globalxp/network/packets/SPacketUpdateXPBlock.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/network/packets/SPacketUpdateXPBlock.java
@@ -11,7 +11,7 @@ import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 public class SPacketUpdateXPBlock implements IMessage
 {
 	private BlockPos pos;
-	private int storedLevels;
+	private int storedXp;
 
 	public SPacketUpdateXPBlock() {}
 	
@@ -21,32 +21,32 @@ public class SPacketUpdateXPBlock implements IMessage
 	 */
 	public SPacketUpdateXPBlock(TileEntityXPBlock te)
 	{
-		this(te.getPos(), te.getStoredLevels());
+		this(te.getPos(), te.getStoredXp());
 	}
 	
 	/**
 	 * Initializes this packet
 	 * @param p The position of the tile entity
-	 * @param sL The amount of stored levels in it
+	 * @param sL The amount of stored xp in it
 	 */
-	public SPacketUpdateXPBlock(BlockPos p, int sL)
+	public SPacketUpdateXPBlock(BlockPos p, int sX)
 	{
 		pos = p;
-		storedLevels = sL;
+		storedXp = sX;
 	}
 	
 	@Override
 	public void toBytes(ByteBuf buf)
 	{
 		buf.writeLong(pos.toLong());
-		buf.writeInt(storedLevels);
+		buf.writeInt(storedXp);
 	}
 	
 	@Override
 	public void fromBytes(ByteBuf buf)
 	{
 		pos = BlockPos.fromLong(buf.readLong());
-		storedLevels = buf.readInt();
+		storedXp = buf.readInt();
 	}
 	
 	public static class Handler implements IMessageHandler<SPacketUpdateXPBlock, IMessage>
@@ -56,7 +56,9 @@ public class SPacketUpdateXPBlock implements IMessage
 		{
 			Minecraft.getMinecraft().addScheduledTask(() -> {
 				if(Minecraft.getMinecraft().world.getTileEntity(message.pos) != null)
-					((TileEntityXPBlock)Minecraft.getMinecraft().world.getTileEntity(message.pos)).setStoredLevels(message.storedLevels);
+				{
+					((TileEntityXPBlock)Minecraft.getMinecraft().world.getTileEntity(message.pos)).setStoredXp(message.storedXp);
+				}
 			});
 			return null;
 		}

--- a/src/main/java/bl4ckscor3/mod/globalxp/renderer/TileEntityXPBlockRenderer.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/renderer/TileEntityXPBlockRenderer.java
@@ -24,7 +24,7 @@ public class TileEntityXPBlockRenderer extends TileEntitySpecialRenderer<TileEnt
 	@Override
 	public void render(TileEntityXPBlock te, double x, double y, double z, float partialTicks, int destroyStage, float alpha)
 	{
-		ITextComponent levelsText = new TextComponentString("" + te.getStoredLevels());
+		ITextComponent levelsText = new TextComponentString("" + (int)te.getStoredLevels());
 		
 		if(te != null && te.getPos() != null && rendererDispatcher.cameraHitResult != null && rendererDispatcher.cameraHitResult.getBlockPos() != null && rendererDispatcher.cameraHitResult.getBlockPos().equals(te.getPos()))
 		{

--- a/src/main/java/bl4ckscor3/mod/globalxp/tileentity/TileEntityXPBlock.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/tileentity/TileEntityXPBlock.java
@@ -7,71 +7,107 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 
+
 public class TileEntityXPBlock extends TileEntity
 {
-	private int storedLevels = 0;
+
+	private int storedXp = 0;
+	private float storedLevels = 0f;
 	
 	/**
-	 * Adds one level to this tile entity and updates all clients within a 64 block range with that change
+	 * Adds xp to this tile entity and updates all clients within a 64 block range with that change
+	 * @param lvl The amount of xp to add
 	 */
-	public void addLevel()
+	public void addXp(int amount)
 	{
-		addLevel(1);
-	}
-	
-	/**
-	 * Adds levels to this tile entity and updates all clients within a 64 block range with that change
-	 * @param lvl The amount of levels to add
-	 */
-	public void addLevel(int lvl)
-	{
-		storedLevels += lvl;
+		storedXp += amount;
 		markDirty();
 		GlobalXP.network.sendToAllAround(new SPacketUpdateXPBlock(this), new NetworkRegistry.TargetPoint(world.provider.getDimension(), pos.getX(), pos.getY(), pos.getZ(), 64));
+		calculateStoredLevels();
 	}
 	
 	/**
-	 * Removes one level from the storage if it is over 0 and updates all clients within a 64 block range with that change
+	 * Removes xp from the storage and returns amount removed.	Updates all clients within a 64 block range with that change
 	 */
-	public void removeLevel()
+	public int removeXp(int amount)
 	{
-		if(storedLevels - 1 < 0)
-			return;
+		int amountRemoved = Math.min(amount, storedXp);
+
+		if(amountRemoved <= 0) {
+			return 0;
+		}
+
+		storedXp -= amountRemoved;
 		
-		storedLevels -= 1;
 		markDirty();
 		GlobalXP.network.sendToAllAround(new SPacketUpdateXPBlock(this), new NetworkRegistry.TargetPoint(world.provider.getDimension(), pos.getX(), pos.getY(), pos.getZ(), 64));
+
+		calculateStoredLevels();
+		return amountRemoved;
 	}
 	
 	/**
-	 * Sets how many levels are stored in this tile entity
-	 * @param levels The amount of levels, non negative
+	 * Sets how much XP is stored in this tile entity
+	 * @param xp The amount of xp
 	 */
-	public void setStoredLevels(int levels)
+	public void setStoredXp(int xp)
 	{
-		storedLevels = levels;
+		storedXp = xp;
+		calculateStoredLevels();
 	}
 	
 	/**
 	 * Gets how many XP are stored in this tile entity
 	 * @return The total amount of XP stored in this tile entity
 	 */
-	public int getStoredLevels()
+	public int getStoredXp()
 	{
+		return storedXp;
+	}
+
+	/**
+	 * Gets how many levels are stored.
+	 * This value is only used for display purposes and does not reflect partial levels
+	*/
+	public float getStoredLevels() {
 		return storedLevels;
+	}
+
+	protected void calculateStoredLevels() {
+		storedLevels = 0f;
+
+		int xp = storedXp;
+		while (xp > 0) {
+			int xpToNextLevel = getXpForLevel((int)storedLevels);
+			if (xp < xpToNextLevel) {
+				storedLevels += (float)xp / xpToNextLevel;
+				break;
+			}
+			xp -= xpToNextLevel;
+			storedLevels += 1.0f;
+		}
+	}
+	
+	// Gets xp requirement to go from level to level+1
+	// formula copied from EntityPlayer.java
+	private int getXpForLevel(int level) {
+		if (level >= 30) {
+			return 112 + (level - 30) * 9;
+		}
+		return level >= 15 ? 37 + (level - 15) * 5 : 7 + level * 2;
 	}
 	
 	@Override
 	public NBTTagCompound writeToNBT(NBTTagCompound tag)
 	{
-		tag.setInteger("stored_levels", storedLevels);
+		tag.setInteger("stored_xp", storedXp);
 		return super.writeToNBT(tag);
 	}
 	
 	@Override
 	public void readFromNBT(NBTTagCompound tag)
 	{
-		storedLevels = tag.getInteger("stored_levels");
+		setStoredXp(tag.getInteger("stored_xp"));
 		super.readFromNBT(tag);
 	}
 	


### PR DESCRIPTION
Shift right-click stores all of player's exp
Right-click extracts exactly how much exp is needed to move player to the next level
Block overlay still shows number of levels.  WailaDataProvider shows fractional levels too
Increase version to 1.4