### PR TITLE
XP Orb Capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,28 @@
 /.gradle
 /libs
 /logs
+/.idea/
+
+# eclipse
+bin
+eclipse
+*.launch
+.settings
+.metadata
+.classpath
+.project
+
+# idea
+out
+*.ipr
+*.iws
+*.iml
+.idea
+
+# gradle
+build
+.gradle
+logs
+
+# other
+run

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ archivesBaseName = 'globalxp'
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
 
 minecraft {
-    mappings channel: 'snapshot', version: '20200916-1.16.2'
+    mappings channel: 'snapshot', version: '20201028-1.16.3'
 	
     runs {
         client {

--- a/src/main/java/bl4ckscor3/mod/globalxp/Configuration.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/Configuration.java
@@ -16,6 +16,7 @@ public class Configuration
 	public DoubleValue bobSpeed;
 	public BooleanValue renderNameplate;
 	public IntValue xpForComparator;
+	public BooleanValue captureXP;
 
 	static
 	{
@@ -39,5 +40,8 @@ public class Configuration
 		xpForComparator = builder
 				.comment("The amount of XP needed for the comparator to output a redstone signal of strength one. By default, the signal will be at full strength if the block has 30 levels stored.")
 				.defineInRange("xpForComparator", 1395 / 15, 0, Integer.MAX_VALUE / 15);
+		captureXP = builder
+				.comment("Whether the XP Block will pickup any XP orbs around it")
+				.define("captureXP", true);
 	}
 }

--- a/src/main/java/bl4ckscor3/mod/globalxp/Configuration.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/Configuration.java
@@ -9,19 +9,28 @@ import net.minecraftforge.common.ForgeConfigSpec.IntValue;
 
 public class Configuration
 {
+	private static final ForgeConfigSpec.Builder COMMON_BUILDER = new ForgeConfigSpec.Builder();
+	private static final ForgeConfigSpec.Builder CLIENT_BUILDER = new ForgeConfigSpec.Builder();
+
+	public static final ForgeConfigSpec CONFIG_COMMON;
 	public static final ForgeConfigSpec CONFIG_SPEC;
 	public static final Configuration CONFIG;
 
+	public static BooleanValue captureXP;
 	public DoubleValue spinSpeed;
 	public DoubleValue bobSpeed;
 	public BooleanValue renderNameplate;
 	public IntValue xpForComparator;
-	public BooleanValue captureXP;
 
 	static
 	{
-		Pair<Configuration,ForgeConfigSpec> specPair = new ForgeConfigSpec.Builder().configure(Configuration::new);
+		// needs to be a configuration option for both Client and Server.
+		captureXP = COMMON_BUILDER
+				.comment("Whether the XP Block will pickup any XP orbs around it")
+				.define("captureXP", true);
+		CONFIG_COMMON = COMMON_BUILDER.build();
 
+		Pair<Configuration,ForgeConfigSpec> specPair = CLIENT_BUILDER.configure(Configuration::new);
 		CONFIG_SPEC = specPair.getRight();
 		CONFIG = specPair.getLeft();
 	}
@@ -40,8 +49,5 @@ public class Configuration
 		xpForComparator = builder
 				.comment("The amount of XP needed for the comparator to output a redstone signal of strength one. By default, the signal will be at full strength if the block has 30 levels stored.")
 				.defineInRange("xpForComparator", 1395 / 15, 0, Integer.MAX_VALUE / 15);
-		captureXP = builder
-				.comment("Whether the XP Block will pickup any XP orbs around it")
-				.define("captureXP", true);
 	}
 }

--- a/src/main/java/bl4ckscor3/mod/globalxp/GlobalXP.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/GlobalXP.java
@@ -33,6 +33,7 @@ public class GlobalXP
 	public GlobalXP()
 	{
 		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, Configuration.CONFIG_SPEC);
+		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Configuration.CONFIG_COMMON);
 	}
 
 	@SubscribeEvent

--- a/src/main/java/bl4ckscor3/mod/globalxp/tileentity/XPBlockTileEntity.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/tileentity/XPBlockTileEntity.java
@@ -12,7 +12,6 @@ import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EntityPredicates;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.world.World;
 
 import java.util.List;
 
@@ -139,7 +138,7 @@ public class XPBlockTileEntity extends TileEntity implements ITickableTileEntity
 
 	@Override
 	public void tick() {
-		if (getWorld().isRemote || !Configuration.CONFIG.captureXP.get()) {
+		if (getWorld().isRemote || !Configuration.captureXP.get()) {
 			return;
 		}
 

--- a/src/main/java/bl4ckscor3/mod/globalxp/tileentity/XPBlockTileEntity.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/tileentity/XPBlockTileEntity.java
@@ -1,15 +1,22 @@
 package bl4ckscor3.mod.globalxp.tileentity;
 
+import bl4ckscor3.mod.globalxp.Configuration;
 import bl4ckscor3.mod.globalxp.GlobalXP;
 import bl4ckscor3.mod.globalxp.util.XPUtils;
 import net.minecraft.block.BlockState;
+import net.minecraft.entity.item.ExperienceOrbEntity;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SUpdateTileEntityPacket;
+import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EntityPredicates;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.world.World;
 
-public class XPBlockTileEntity extends TileEntity
-{
+import java.util.List;
+
+public class XPBlockTileEntity extends TileEntity implements ITickableTileEntity {
 	private int storedXP = 0;
 	private float storedLevels = 0.0F;
 	private boolean destroyedByCreativePlayer;
@@ -126,5 +133,71 @@ public class XPBlockTileEntity extends TileEntity
 	{
 		setStoredXP(tag.getInt("stored_xp"));
 		super.read(state, tag);
+	}
+
+	private int modifierAmount = 0;
+
+	@Override
+	public void tick() {
+		if (getWorld().isRemote || !Configuration.CONFIG.captureXP.get()) {
+			return;
+		}
+
+		if (getWorld().getGameTime() % 5 == 0) {
+			captureDroppedXP();
+		}
+	}
+
+	private void captureDroppedXP() {
+		for (ExperienceOrbEntity entity : getCaptureXP()) {
+			int amount = entity.getXpValue();
+			if (entity.isAlive() && getStoredXP() + amount <= getCapacity()) {
+				addXP(amount);
+				entity.remove();
+			}
+		}
+	}
+
+	/**
+	 * Gets all the xp orbs within a certain area around the tile entity.
+	 */
+	private List<ExperienceOrbEntity> getCaptureXP() {
+		return getWorld().<ExperienceOrbEntity>getEntitiesWithinAABB(ExperienceOrbEntity.class, getAABBWithModifiers(), EntityPredicates.IS_ALIVE);
+	}
+
+	/**
+	 * Gets the area around the tile entity to search for xp orbs.
+	 */
+	private AxisAlignedBB getAABBWithModifiers() {
+		double x = getPos().getX() + 0.5D;
+		double y = getPos().getY() + 0.5D;
+		double z = getPos().getZ() + 0.5D;
+
+		return new AxisAlignedBB(x - 3.5D - getModifierAmount(), y - 3.5D - getModifierAmount(), z - 3.5D - getModifierAmount(), x + 3.5D + getModifierAmount(), y + 3.5D + getModifierAmount(), z + 3.5D + getModifierAmount());
+	}
+
+	/**
+	 * Gets the total amount of XP that can be stored in this tile entity
+	 * @return The total amount of XP that can be stored in this tile entity
+	 */
+	public int getCapacity() {
+		return Integer.MAX_VALUE;
+	}
+
+	/**
+	 * Gets the amount of the area modifier.
+	 * Used to increase/decrease the search area.
+	 * @return The modifier amount to increase the search area.
+	 */
+	public int getModifierAmount() {
+		return modifierAmount;
+	}
+
+	/**
+	 * Sets the amount of the area modifier.
+	 * Used to increase/decrease the search area.
+	 */
+	public void setModifierAmount(int amount) {
+		modifierAmount = Math.max(0, amount);
 	}
 }

--- a/src/main/resources/assets/globalxp/lang/en_us.json
+++ b/src/main/resources/assets/globalxp/lang/en_us.json
@@ -7,5 +7,7 @@
     "globalxp.config.bobspeed": "Emerald bob speed",
     "globalxp.config.bobspeed.tooltip": "How fast the emerald should bob up and down (multiplier of the default speed)",
     "globalxp.config.renderNameplate": "Show XP info",
-    "globalxp.config.renderNameplate.tooltip": "Whether info about the saved levels should be shown above the XP Block"
+    "globalxp.config.renderNameplate.tooltip": "Whether info about the saved levels should be shown above the XP Block",
+    "globalxp.config.captureXP": "Capture XP Orbs",
+    "globalxp.config.captureXP.tooltip": "Whether the XP Block will pickup any XP orbs around it"
 }


### PR DESCRIPTION
1. added the ability for the XP block to capture XP orbs.
2. added a config setting to enable/disable capture XP orb - default true.
Radius of ~3 blocks in all directions.

Implemented a modifier amount that can increase the area, but have not adding anything to change it, modifier defaulted to 0 (0 blocks), so uses standard ranges of ~3 blocks.
Could implement a GUI or implement some type of upgrade to increase the modifier, so even make it a config setting.