### PR TITLE
Fix storing more than ~15000 levels of experience

### DIFF
--- a/src/main/java/bl4ckscor3/mod/globalxp/XPUtils.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/XPUtils.java
@@ -38,7 +38,7 @@ public class XPUtils {
 	 */
 	public static int getXPToNextLevel(long currentXP) {
 		int level = EnchantmentUtils.getLevelForExperience(currentXP);
-		int nextLevelXP = EnchantmentUtils.getExperienceForLevel(level + 1);
+		long nextLevelXP = EnchantmentUtils.getExperienceForLevel(level + 1);
 
 		return nextLevelXP - currentXP;
 	}

--- a/src/main/java/bl4ckscor3/mod/globalxp/XPUtils.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/XPUtils.java
@@ -11,9 +11,9 @@ public class XPUtils {
 	 * @param storedXP The amount of XP to get the level amount of
 	 * @return The amount of levels storedXP represents
 	 */
-	public static float calculateStoredLevels(int storedXP) {
+	public static float calculateStoredLevels(long storedXP) {
 		float storedLevels = 0.0F;
-		int xp = storedXP;
+		long xp = storedXP;
 
 		while (xp > 0) {
 			int xpToNextLevel = EnchantmentUtils.xpBarCap((int) storedLevels);
@@ -36,7 +36,7 @@ public class XPUtils {
 	 * @param currentXP The XP that the player already has
 	 * @return
 	 */
-	public static int getXPToNextLevel(int currentXP) {
+	public static int getXPToNextLevel(long currentXP) {
 		int level = EnchantmentUtils.getLevelForExperience(currentXP);
 		int nextLevelXP = EnchantmentUtils.getExperienceForLevel(level + 1);
 

--- a/src/main/java/bl4ckscor3/mod/globalxp/openmods/utils/EnchantmentUtils.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/openmods/utils/EnchantmentUtils.java
@@ -23,12 +23,12 @@ public class EnchantmentUtils {
 	 * @param player The player to get the XP of
 	 * @return The amount of XP the given player has
 	 */
-	public static int getPlayerXP(Player player) {
-		return (int) (EnchantmentUtils.getExperienceForLevel(player.experienceLevel) + (player.experienceProgress * player.getXpNeededForNextLevel()));
+	public static long getPlayerXP(Player player) {
+		return (long) (EnchantmentUtils.getExperienceForLevel(player.experienceLevel) + (player.experienceProgress * player.getXpNeededForNextLevel()));
 	}
 
-	public static void addPlayerXP(Player player, int amount) {
-		int experience = getPlayerXP(player) + amount;
+	public static void addPlayerXP(Player player, long amount) {
+		long experience = getPlayerXP(player) + amount;
 		int expForLevel;
 
 		player.totalExperience = experience;
@@ -46,11 +46,11 @@ public class EnchantmentUtils {
 		return 7 + level * 2;
 	}
 
-	private static int sum(int n, int a0, int d) {
+	private static long sum(long n, long a0, long d) {
 		return n * (2 * a0 + (n - 1) * d) / 2;
 	}
 
-	public static int getExperienceForLevel(int level) {
+	public static long getExperienceForLevel(int level) {
 		if (level == 0)
 			return 0;
 
@@ -60,10 +60,10 @@ public class EnchantmentUtils {
 		if (level <= 30)
 			return 315 + sum(level - 15, 37, 5);
 
-		return 1395 + sum(level - 30, 112, 9);
+		return 1395L + sum((long)(level - 30), 112L, 9L);
 	}
 
-	public static int getLevelForExperience(int targetXp) {
+	public static int getLevelForExperience(long targetXp) {
 		int level = 0;
 
 		while (true) {

--- a/src/main/java/bl4ckscor3/mod/globalxp/openmods/utils/EnchantmentUtils.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/openmods/utils/EnchantmentUtils.java
@@ -29,9 +29,9 @@ public class EnchantmentUtils {
 
 	public static void addPlayerXP(Player player, long amount) {
 		long experience = getPlayerXP(player) + amount;
-		int expForLevel;
+		long expForLevel;
 
-		player.totalExperience = experience;
+		player.totalExperience = (int)Math.min(Integer.MAX_VALUE, experience);
 		player.experienceLevel = EnchantmentUtils.getLevelForExperience(experience);
 		expForLevel = EnchantmentUtils.getExperienceForLevel(player.experienceLevel);
 		player.experienceProgress = (experience - expForLevel) / (float) player.getXpNeededForNextLevel();

--- a/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlock.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlock.java
@@ -55,7 +55,7 @@ public class XPBlock extends BaseEntityBlock {
 					if (GlobalXP.CONFIG.storingAmount != -1)
 						xpToStore = Math.min(GlobalXP.CONFIG.storingAmount, EnchantmentUtils.getPlayerXP(player));
 					else if (GlobalXP.CONFIG.storeUntilPreviousLevel) {
-						int xpForCurrentLevel = EnchantmentUtils.getExperienceForLevel(player.experienceLevel);
+						long xpForCurrentLevel = EnchantmentUtils.getExperienceForLevel(player.experienceLevel);
 
 						xpToStore = EnchantmentUtils.getPlayerXP(player) - xpForCurrentLevel;
 

--- a/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlock.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlock.java
@@ -103,7 +103,7 @@ public class XPBlock extends BaseEntityBlock {
 			Level level = player.level();
 
 			if (!level.isClientSide) {
-				ExperienceOrb orb = new ExperienceOrb(level, player.getX(), player.getY(), player.getZ(), amount);
+				ExperienceOrb orb = new ExperienceOrb(level, player.getX(), player.getY(), player.getZ(), (int)amount);
 
 				orb.addTag("GlobalXPMarker"); //so the xp block won't pick it back up
 				level.addFreshEntity(orb);
@@ -121,7 +121,7 @@ public class XPBlock extends BaseEntityBlock {
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level level, BlockPos pos) {
 		if (level.getBlockEntity(pos) instanceof XPBlockEntity xpBlock)
-			return Math.min(15, Math.floorDiv(xpBlock.getStoredXP(), GlobalXP.CONFIG.xpForComparator));
+			return (int)Math.min(15, Math.floorDiv(xpBlock.getStoredXP(), GlobalXP.CONFIG.xpForComparator));
 		else
 			return 0;
 	}

--- a/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlock.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlock.java
@@ -141,7 +141,7 @@ public class XPBlock extends BaseEntityBlock {
 				if (stackTag.contains("BlockEntityTag"))
 					stackTag = stackTag.getCompound("BlockEntityTag");
 
-				xpBlock.setStoredXP(stackTag.getInt("stored_xp"));
+				xpBlock.setStoredXP(stackTag.getLong("stored_xp"));
 			}
 		}
 	}

--- a/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlock.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlock.java
@@ -50,7 +50,7 @@ public class XPBlock extends BaseEntityBlock {
 		if (level.getBlockEntity(pos) instanceof XPBlockEntity xpBlock) {
 			if (!level.isClientSide) {
 				if (player.isShiftKeyDown()) {
-					int xpToStore = 0;
+					long xpToStore = 0;
 
 					if (GlobalXP.CONFIG.storingAmount != -1)
 						xpToStore = Math.min(GlobalXP.CONFIG.storingAmount, EnchantmentUtils.getPlayerXP(player));
@@ -73,17 +73,17 @@ public class XPBlock extends BaseEntityBlock {
 					return InteractionResult.SUCCESS;
 				}
 				else if (!player.isShiftKeyDown()) {
-					int xpRetrieved;
+					long xpRetrieved;
 
 					if (GlobalXP.CONFIG.retrievalAmount != -1)
-						xpRetrieved = (int) (xpBlock.removeXP(GlobalXP.CONFIG.retrievalAmount) * GlobalXP.CONFIG.retrievalPercentage);
+						xpRetrieved = (long) (xpBlock.removeXP(GlobalXP.CONFIG.retrievalAmount) * GlobalXP.CONFIG.retrievalPercentage);
 					else if (GlobalXP.CONFIG.retriveUntilNextLevel) {
-						int xpToRetrieve = EnchantmentUtils.getExperienceForLevel(player.experienceLevel + 1) - EnchantmentUtils.getPlayerXP(player);
+						long xpToRetrieve = EnchantmentUtils.getExperienceForLevel(player.experienceLevel + 1) - EnchantmentUtils.getPlayerXP(player);
 
-						xpRetrieved = (int) (xpBlock.removeXP(xpToRetrieve) * GlobalXP.CONFIG.retrievalPercentage);
+						xpRetrieved = (long) (xpBlock.removeXP(xpToRetrieve) * GlobalXP.CONFIG.retrievalPercentage);
 					}
 					else {
-						xpRetrieved = (int) (xpBlock.getStoredXP() * GlobalXP.CONFIG.retrievalPercentage);
+						xpRetrieved = (long) (xpBlock.getStoredXP() * GlobalXP.CONFIG.retrievalPercentage);
 						xpBlock.setStoredXP(0);
 					}
 
@@ -98,7 +98,7 @@ public class XPBlock extends BaseEntityBlock {
 		return InteractionResult.PASS;
 	}
 
-	private void addOrSpawnXPForPlayer(Player player, int amount) {
+	private void addOrSpawnXPForPlayer(Player player, long amount) {
 		if (GlobalXP.CONFIG.retrieveXPOrbs) {
 			Level level = player.level();
 
@@ -168,7 +168,7 @@ public class XPBlock extends BaseEntityBlock {
 			if (xpBlock.getStoredLevels() != 0) {
 				CompoundTag stackTag = stack.getOrCreateTag();
 
-				stackTag.putInt("stored_xp", xpBlock.getStoredXP());
+				stackTag.putLong("stored_xp", xpBlock.getStoredXP());
 				popResource(level, pos, stack);
 			}
 			else if (!xpBlock.isDestroyedByCreativePlayer())

--- a/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlockEntity.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlockEntity.java
@@ -17,7 +17,7 @@ import net.minecraft.world.phys.AABB;
 
 public class XPBlockEntity extends BlockEntity implements Nameable {
 	private Component name;
-	private int storedXP = 0;
+	private long storedXP = 0;
 	private float storedLevels = 0.0F;
 	private boolean destroyedByCreativePlayer;
 
@@ -30,7 +30,7 @@ public class XPBlockEntity extends BlockEntity implements Nameable {
 	 *
 	 * @param amount The amount of XP to add
 	 */
-	public void addXP(int amount) {
+	public void addXP(long amount) {
 		storedXP += amount;
 		storedLevels = XPUtils.calculateStoredLevels(storedXP);
 		setChanged();
@@ -43,8 +43,8 @@ public class XPBlockEntity extends BlockEntity implements Nameable {
 	 * @param amount The amount of XP to remove
 	 * @return The amount of XP that has been removed
 	 */
-	public int removeXP(int amount) {
-		int amountRemoved = Math.min(amount, storedXP);
+	public long removeXP(long amount) {
+		long amountRemoved = Math.min(amount, storedXP);
 
 		if (amountRemoved <= 0)
 			return 0;
@@ -71,7 +71,7 @@ public class XPBlockEntity extends BlockEntity implements Nameable {
 	 *
 	 * @param xp The amount of XP
 	 */
-	public void setStoredXP(int xp) {
+	public void setStoredXP(long xp) {
 		storedXP = xp;
 		storedLevels = XPUtils.calculateStoredLevels(storedXP);
 		setChanged();
@@ -85,7 +85,7 @@ public class XPBlockEntity extends BlockEntity implements Nameable {
 	 *
 	 * @return The total amount of XP stored in this block entity
 	 */
-	public int getStoredXP() {
+	public long getStoredXP() {
 		return storedXP;
 	}
 
@@ -114,7 +114,7 @@ public class XPBlockEntity extends BlockEntity implements Nameable {
 
 	@Override
 	public void saveAdditional(CompoundTag tag) {
-		tag.putInt("stored_xp", storedXP);
+		tag.putLong("stored_xp", storedXP);
 
 		if (name != null)
 			tag.putString("CustomName", Component.Serializer.toJson(name));
@@ -123,7 +123,7 @@ public class XPBlockEntity extends BlockEntity implements Nameable {
 	@Override
 	public void load(CompoundTag tag) {
 		super.load(tag);
-		setStoredXP(tag.getInt("stored_xp"));
+		setStoredXP(tag.getLong("stored_xp"));
 
 		if (tag.contains("CustomName", Tag.TAG_STRING))
 			name = Component.Serializer.fromJson(tag.getString("CustomName"));
@@ -163,8 +163,8 @@ public class XPBlockEntity extends BlockEntity implements Nameable {
 	 *
 	 * @return The total amount of XP that can be stored in this block entity
 	 */
-	public int getCapacity() {
-		return Integer.MAX_VALUE;
+	public long getCapacity() {
+		return Long.MAX_VALUE;
 	}
 
 	public void setCustomName(Component name) {

--- a/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlockItem.java
+++ b/src/main/java/bl4ckscor3/mod/globalxp/xpblock/XPBlockItem.java
@@ -27,17 +27,17 @@ public class XPBlockItem extends BlockItem {
 			addInfo(tooltip, "0", 0);
 		else {
 			CompoundTag stackTag = stack.getTag();
-			int storedXP;
+			long storedXP;
 
 			if (stackTag.contains(BLOCK_ENTITY_TAG))
 				stackTag = stackTag.getCompound(BLOCK_ENTITY_TAG);
 
-			storedXP = stackTag.getInt("stored_xp");
+			storedXP = stackTag.getLong("stored_xp");
 			addInfo(tooltip, String.format("%.2f", XPUtils.calculateStoredLevels(storedXP)), storedXP);
 		}
 	}
 
-	public void addInfo(List<Component> tooltip, String storedLevels, int storedXP) {
+	public void addInfo(List<Component> tooltip, String storedLevels, long storedXP) {
 		tooltip.add(Component.translatable("info.globalxp.levels", storedLevels).setStyle(STYLE));
 		tooltip.add(Component.translatable("info.globalxp.xp", storedXP).setStyle(STYLE));
 	}


### PR DESCRIPTION
When you store too much experience, it would overflow into negative numbers. I changed the necessary numbers to be `long` type instead of `int` in order to prevent this.

The reasoning is that in vanilla survival it is (technically) possible to get way more than the ~15000 that is possible with the `int` type.